### PR TITLE
hover show detail feature + minor bug fix

### DIFF
--- a/src/vscode-atopile/bundled/tool/lsp_server.py
+++ b/src/vscode-atopile/bundled/tool/lsp_server.py
@@ -194,6 +194,58 @@ def completions(params: Optional[lsp.CompletionParams] = None) -> lsp.Completion
     return lsp.CompletionList(is_incomplete=False, items=items,)
 
 
+@LSP_SERVER.feature(lsp.TEXT_DOCUMENT_HOVER)
+def hover_definition(params: lsp.HoverParams) -> Optional[lsp.Hover]:
+    if not params.text_document.uri.startswith("file://"):
+        return lsp.CompletionList(is_incomplete=False, items=[])
+
+    document = LSP_SERVER.workspace.get_text_document(params.text_document.uri)
+
+    file = Path(document.path)
+    try:
+        atopile.config.get_project_context()
+    except ValueError:
+        atopile.config.set_project_context(atopile.config.ProjectContext.from_path(file))
+    class_addr = _get_def_addr_from_line(file, params.position.line)
+    if not class_addr:
+        class_addr = str(file)
+
+    word, range_ = utils.cursor_word_and_range(document, params.position)
+    try:
+        word = word[:word.index(".", params.position.character - range_.start.character)]
+    except ValueError:
+        pass
+    word = utils.remove_special_character(word)
+    output_str = ""
+
+    # check if it is an instance
+    try:
+        instance_addr = atopile.address.add_instances(class_addr, word.split("."))
+        instance = atopile.front_end.lofty.get_instance(instance_addr)
+    except (KeyError, atopile.errors.AtoError, AttributeError):
+        pass
+    else:
+        # TODO: deal with assignments made to super
+        output_str += f"**class**: {str(atopile.address.get_name(instance.supers[0].address))}\n\n"
+        for key, assignment in instance.assignments.items():
+            output_str += "**"+key+"**: "
+            if (assignment[0] is None):
+                output_str += 'not assigned\n\n'
+            else:
+                output_str += str(assignment[0].value) +'\n\n'
+
+    # check if it is an assignment
+    class_assignments = atopile.front_end.dizzy.get_layer(class_addr).assignments.get(word, None)
+    if class_assignments:
+        output_str = str(class_assignments.value)
+
+    if output_str:
+        return lsp.Hover(contents=lsp.MarkupContent(
+                        kind=lsp.MarkupKind.Markdown,
+                        value=output_str.strip(),
+                    ))
+    return None
+
 @LSP_SERVER.feature(lsp.TEXT_DOCUMENT_DEFINITION)
 def goto_definition(params: Optional[lsp.DefinitionParams] = None) -> Optional[lsp.Location]:
     """Handler for goto definition."""
@@ -207,7 +259,6 @@ def goto_definition(params: Optional[lsp.DefinitionParams] = None) -> Optional[l
         atopile.config.get_project_context()
     except ValueError:
         atopile.config.set_project_context(atopile.config.ProjectContext.from_path(file))
-
     class_addr = _get_def_addr_from_line(file, params.position.line)
     if not class_addr:
         class_addr = str(file)
@@ -217,9 +268,11 @@ def goto_definition(params: Optional[lsp.DefinitionParams] = None) -> Optional[l
         word = word[:word.index(".", params.position.character - range_.start.character)]
     except ValueError:
         pass
+    word = utils.remove_special_character(word)
 
     # See if it's an instance
     instance_addr = atopile.address.add_instances(class_addr, word.split("."))
+
     src_ctx = None
     try:
         src_ctx = atopile.front_end.lofty.get_instance(instance_addr).src_ctx

--- a/src/vscode-atopile/bundled/tool/lsp_utils.py
+++ b/src/vscode-atopile/bundled/tool/lsp_utils.py
@@ -68,6 +68,9 @@ def cursor_word_and_range(
             return word
     return None
 
+def remove_special_character(word: str) -> str:
+    return "".join(e for e in word if e not in "(){}")
+
 def as_list(content: Union[Any, List[Any], Tuple[Any]]) -> Union[List[Any], Tuple[Any]]:
     """Ensures we always get a list"""
     if isinstance(content, (list, tuple)):

--- a/src/vscode-atopile/package.json
+++ b/src/vscode-atopile/package.json
@@ -39,7 +39,8 @@
         "virtualWorkspaces": {
             "supported": false,
             "description": "Virtual Workspaces are not supported with atopile."
-        }
+        },
+        "hoverProvider" : "true"
     },
     "activationEvents": [
         "onLanguage:atopile",


### PR DESCRIPTION
Shows details on hover: gives class name + variable values for instances and assigned value for variables. Minor bug fix for when bracket is in a word.

<!-- greptile_comment -->

## Greptile Summary

- Introduced hover feature to display class names and variable values
- Fixed bug for handling brackets within words
- Added `hoverProvider` capability in `package.json`
- New utility function `remove_special_character` for text cleanup

<!-- /greptile_comment -->